### PR TITLE
Applying URI parsing fix to address URI.encode deprecation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ bower.json
 # Ignore node_modules
 node_modules/
 
+.idea/

--- a/lib/wine_shipping/api_client.rb
+++ b/lib/wine_shipping/api_client.rb
@@ -266,7 +266,7 @@ module WineShipping
     def build_request_url(path)
       # Add leading and trailing slashes to path
       path = "/#{path}".gsub(/\/+/, '/')
-      URI.encode(@config.base_url + path)
+      URI::Parser.new.escape(@config.base_url + path)
     end
 
     # Builds the HTTP request body

--- a/lib/wine_shipping/configuration.rb
+++ b/lib/wine_shipping/configuration.rb
@@ -175,7 +175,7 @@ module WineShipping
 
     def base_url
       url = "#{scheme}://#{[host, base_path].join('/').gsub(/\/+/, '/')}".sub(/\/+\z/, '')
-      URI.encode(url)
+      URI::Parser.new.escape(url)
     end
 
     # Gets API key (with prefix if set).


### PR DESCRIPTION
@joshreeves 

**Problem**
In ruby 2.7.5, "URI.escape" is deprecated. The lines in this PR fail when attempting to use this function.

**Solution**
Implement the fix that the original repository has made here that addresses this issue: 

https://github.com/penrosehill/wine_shipping/pull/5